### PR TITLE
Remove .yml extension

### DIFF
--- a/.github/workflows/.yamllint.yml
+++ b/.github/workflows/.yamllint.yml
@@ -1,3 +1,0 @@
-rules:
-  line-length:
-    max: 128


### PR DESCRIPTION
**WHAT**

Remove `.yml` extension from yamllint configuration file.

**WHY**
Try to prevent GitHub actions from trying to run the yamllint configuration(!)